### PR TITLE
Added From Name to PHPMailerSender.class.php

### DIFF
--- a/backend/include/Settings.class.php
+++ b/backend/include/Settings.class.php
@@ -36,6 +36,7 @@ class Settings {
 		"forbidden_file_upload_types" => array(),
 		"firebug_logging" => FALSE,
 		"mail_notification_from" => "Admin",
+		"mail_notification_from_name" => "Administrator",
 		"new_folder_permission_mask" => 0755,
 		"convert_filenames" => FALSE,
 		"support_output_buffer" => FALSE,

--- a/backend/include/mail/PHPMailerSender.class.php
+++ b/backend/include/mail/PHPMailerSender.class.php
@@ -23,6 +23,7 @@
 			
 			$isHtml = (stripos($message, "<html>") !== FALSE);
 			$f = ($from != NULL ? $from : $this->env->settings()->setting("mail_notification_from"));
+			$fName = $this->env->settings()->setting("mail_notification_from_name");
 			
 			$validRecipients = $this->getValidRecipients($to);
 			if (count($validRecipients) === 0) {
@@ -53,6 +54,7 @@
 			}
 			
 			$mailer->From = $f;
+			$mailer->FromName = $fName;
 			foreach ($validRecipients as $recipient) {
 				$mailer->addBCC($recipient["email"], $recipient["name"]);
 			}


### PR DESCRIPTION
I wanted to use the functionality "Sender Name sender@domain.com" with
the PHPMailerSender but it didnt work so this is a small fix to have the
additional property "mail_notification_from_name" which provides the
sender's name.
