### PR TITLE
Check underlying permissions per item, not per filesystem root

### DIFF
--- a/backend/include/filesystem/KloudspeakerFilesystem.class.php
+++ b/backend/include/filesystem/KloudspeakerFilesystem.class.php
@@ -24,7 +24,7 @@
 			return FALSE;
 		}
 
-		public function isWritable() {
+		public function isWritable($item) {
 			return TRUE;
 		}
 

--- a/backend/include/filesystem/LocalFilesystem.class.php
+++ b/backend/include/filesystem/LocalFilesystem.class.php
@@ -23,8 +23,8 @@ class LocalFilesystem extends KloudspeakerFilesystem {
 		$this->rootPath = self::folderPath($def["path"]);
 	}
 
-	public function isWritable() {
-		return is_writable($this->rootPath);
+	public function isWritable($item) {
+		return is_writable($this->localPath($item));
 	}
 
 	public function isDirectDownload() {

--- a/backend/include/permissions/PermissionsController.class.php
+++ b/backend/include/permissions/PermissionsController.class.php
@@ -197,7 +197,7 @@ class Kloudspeaker_PermissionsController {
 		}
 
 		// special case for readonly filesystem, overrides system permissions
-		if (isset($result[FilesystemController::FILESYSTEM_ITEM_ACCESS_PERMISSION]) and !$item->filesystem()->isWritable()) {
+		if (isset($result[FilesystemController::FILESYSTEM_ITEM_ACCESS_PERMISSION]) and !$item->filesystem()->isWritable($item)) {
 			$values = $this->filesystemPermissions[FilesystemController::FILESYSTEM_ITEM_ACCESS_PERMISSION];
 			$maxIndex = array_search(FilesystemController::PERMISSION_LEVEL_READ, $values);
 			$index = array_search($result[FilesystemController::FILESYSTEM_ITEM_ACCESS_PERMISSION], $values);


### PR DESCRIPTION
This is what I originally intended in #62 but perhaps it was misunderstood. I have also applied the character set conversion that is done for other native filesystem operations.
