### PR TITLE
PDODatabase: If mysql, must replce {ENGINE} in sql files

### DIFF
--- a/backend/db/pdo/PDODatabase.class.php
+++ b/backend/db/pdo/PDODatabase.class.php
@@ -171,6 +171,9 @@ class PDODatabase {
 		}
 
 		$sql = str_replace('{TABLE_PREFIX}', (isset($this->tablePrefix) and $this->tablePrefix != '') ? $this->tablePrefix : '', $sql);
+		if ($this->type == "mysql") {
+			$sql = str_replace('{ENGINE}', (isset($this->engine) and $this->engine != '') ? $this->engine : 'innodb', $sql);
+		}
 		$this->queries($sql);
 	}
 


### PR DESCRIPTION
Encountered an issue during install: if using PDO + MySql, the PDODatabase class fails to replace {ENGINE} like the MySQLDatabase class.

Config used:

```
"db" => array(
        "type" => "pdo",
        "str" => "mysql:host=localhost;dbname=kloudspeaker",
        "database" => "kloudspeaker",
        "user" => "kloudspeaker",
        "password" => "password",
        "charset" => "utf8",
    ),
```
